### PR TITLE
Fix eslint errors and warnings for next apps

### DIFF
--- a/plugin/src/generators/next-app/files/app/[locale]/layout.tsx.template
+++ b/plugin/src/generators/next-app/files/app/[locale]/layout.tsx.template
@@ -1,7 +1,7 @@
-import { constants, Locale } from '../../constants';
 import { notFound } from 'next/navigation';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import { ReactElement, ReactNode } from 'react';
+import { constants, Locale } from '../../constants';
 import { Providers } from './providers';
 
 export const metadata = {

--- a/plugin/src/generators/next-app/files/app/[locale]/page.tsx.template
+++ b/plugin/src/generators/next-app/files/app/[locale]/page.tsx.template
@@ -1,7 +1,7 @@
+import { useTranslations } from 'next-intl';
+import { unstable_setRequestLocale } from 'next-intl/server';
 import { ReactElement } from 'react';
 import { Locale } from '../../constants';
-import { unstable_setRequestLocale } from 'next-intl/server';
-import { useTranslations } from 'next-intl';
 
 export interface IndexPageProps {
   params: { locale: Locale };

--- a/plugin/src/generators/next-app/files/app/[locale]/providers.tsx.template
+++ b/plugin/src/generators/next-app/files/app/[locale]/providers.tsx.template
@@ -1,5 +1,5 @@
-import { ReactElement } from 'react';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
+import { ReactElement } from 'react';
 
 export function Providers({
   children,

--- a/plugin/src/generators/next-app/files/middleware.ts.template
+++ b/plugin/src/generators/next-app/files/middleware.ts.template
@@ -1,5 +1,5 @@
-import { constants } from './constants';
 import createMiddleware from 'next-intl/middleware';
+import { constants } from './constants';
 
 export default createMiddleware({
   locales: constants.locales,

--- a/plugin/src/generators/next-app/generator.ts
+++ b/plugin/src/generators/next-app/generator.ts
@@ -40,6 +40,7 @@ export async function nextAppGenerator(
   tree.delete(`${appRoot}/app/page.module.scss`);
   tree.delete(`${appRoot}/app/global.css`);
   tree.delete(`${appRoot}/app/layout.tsx`);
+  tree.delete(`${appRoot}/specs`);
   tree.delete(`${appRoot}/.eslintrc.json`);
 
   // Update app tsconfig.json to skip automatic reconfiguration during the first application run


### PR DESCRIPTION
This PR addresses errors and warnings for apps created using the `next-app` generator.

Here's a summary of the changes:

- The `next-app` generator now removes the specs folder inside the generated app. This folder is automatically created when setting up workspaces with the `next` preset, and there seems to be no way to disable this behavior, so we delete it manually.
- Imports in the generated files have been reorganized to fix `eslint` warnings related to the `import/order` rule.