### PR TITLE
FIX: replace windows path separators in lib paths

### DIFF
--- a/plugin/src/generators/lib-move/generator.ts
+++ b/plugin/src/generators/lib-move/generator.ts
@@ -46,7 +46,10 @@ export async function libMoveGenerator(tree: Tree, options: LibMoveGeneratorSche
       defaultLibraryName,
     ));
   const libDirectoryName = getLibDirectoryName(libraryName, options.scope);
-  const newLibImportPath = `${path.normalize(`${options.app}/${options.scope}/${options.type}/${libDirectoryName}`)}`;
+  const newLibImportPath = path
+    .normalize(`${options.app}/${options.scope}/${options.type}/${libDirectoryName}`)
+    .split(path.sep)
+    .join('/');
   const newLibPath = `libs/${newLibImportPath}`;
   const fullLibraryPath = `${getImportPathPrefix(tree)}/${newLibImportPath}`;
   const fullLibraryName = newLibImportPath.split('/').join('-');

--- a/plugin/src/generators/lib-rename/generator.ts
+++ b/plugin/src/generators/lib-rename/generator.ts
@@ -20,7 +20,10 @@ export async function libRenameGenerator(tree: Tree, options: LibRenameGenerator
   libPathSegments.push(destLibraryName);
 
   const destLibraryPath = `libs/${libPathSegments.join('/')}`;
-  const newLibImportPath = path.normalize(libPathSegments.join('/'));
+  const newLibImportPath = path
+    .normalize(libPathSegments.join('/'))
+    .split(path.sep)
+    .join('/');
   const fullLibraryPath = `${getImportPathPrefix(tree)}/${newLibImportPath}`;
   const fullLibraryName = newLibImportPath.split('/').join('-');
 

--- a/plugin/src/generators/react-lib/generator.ts
+++ b/plugin/src/generators/react-lib/generator.ts
@@ -58,7 +58,10 @@ export async function reactLibGenerator(tree: Tree, options: ReactLibGeneratorSc
   const tags = [`app:${options.app}`, `scope:${scopeTag}`, `type:${options.type}`];
 
   const libDirectoryName = getLibDirectoryName(options.name, options.scope);
-  const libName = path.normalize(`${options.app}/${options.scope}/${options.type}/${libDirectoryName}`);
+  const libName = path
+    .normalize(`${options.app}/${options.scope}/${options.type}/${libDirectoryName}`)
+    .split(path.sep)
+    .join('/');
   const libPath = `libs/${libName}`;
   const command = `npx nx g @nx/expo:lib --skipPackageJson --unitTestRunner=none --tags="${tags.join(', ')}" --name=${libName} ${libPath} --linter=eslint`;
   const commandWithOptions = options.dryRun ? command + ' --dry-run' : command;


### PR DESCRIPTION
Current behavior on Windows:
<details>
  <summary>Screenshot</summary>
  
![photo_2025-02-28_11-17-23](https://github.com/user-attachments/assets/d8ec7395-d144-4a4b-8be1-0909054d85ac)

</details>