### PR TITLE
fix: adjust sentry generator for expo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,13 @@ The `plugin` directory contains the source code for all generators in this packa
    - Release alpha version of the package: `npm run release -- --tag=alpha`
    - Install the package in your test environment: `npm i @ronas-it/nx-generators@alpha --save-dev`
 
-5. **Submit changes**
+5. **Test locally in another project with Yalc (Optional)**
+   - [Yalc](https://github.com/wclr/yalc) is a small local package store so other repos can depend on your build without publishing to npm. Install once: `npm i yalc -g`
+   - From the repository root run `npm run build`, then `cd dist/nx-generators` and `yalc publish` (publish this folder, not `plugin/` — it matches what npm ships)
+   - In the consumer project run `yalc add @ronas-it/nx-generators`
+   - When you iterate here, publish again from `dist/nx-generators`, or use `yalc publish --push` to refresh existing installs
+
+6. **Submit changes**
    - Create a pull request with your modifications
    - Include clear descriptions of changes
    - Reference any related issues or discussions

--- a/plugin/src/generators/expo-app/scripts.ts
+++ b/plugin/src/generators/expo-app/scripts.ts
@@ -9,6 +9,6 @@ export default {
   'update:prod': 'cross-env EXPO_PUBLIC_APP_ENV=production eas update --branch production',
   'submit:dev': 'cross-env EXPO_PUBLIC_APP_ENV=development eas submit --no-wait --profile=development',
   'submit:prod': 'cross-env EXPO_PUBLIC_APP_ENV=production eas submit --no-wait --profile=production',
-  android: 'npx expo run:android',
-  ios: 'npx expo run:ios',
+  android: 'cross-env EXPO_PUBLIC_APP_ENV=development npx expo run:android',
+  ios: 'cross-env EXPO_PUBLIC_APP_ENV=development npx expo run:ios',
 };

--- a/plugin/src/generators/sentry/generator.spec.ts
+++ b/plugin/src/generators/sentry/generator.spec.ts
@@ -147,6 +147,11 @@ describe('generateSentryExpo', () => {
 
     expect(layout).toContain('Sentry.init({');
     expect(layout).toContain('dsn: Constants.expoConfig?.extra?.sentry?.dsn');
+
+    const appConfig = tree.read(`${projectRoot}/app.config.ts`, 'utf-8');
+
+    expect(appConfig).toContain(`dsn: "${dsn}"`);
+    expect(appConfig).toContain('sentry:');
   });
 });
 

--- a/plugin/src/generators/sentry/utils/generate-sentry-expo.ts
+++ b/plugin/src/generators/sentry/utils/generate-sentry-expo.ts
@@ -41,7 +41,7 @@ const updateExtraConfig = (content: string, dsn: string): string =>
   createPrinter().printFile(
     tsquery.map(
       tsquery.ast(content),
-      'VariableDeclaration > Identifier[name="extra"] ~ ObjectLiteralExpression',
+      'VariableDeclaration:has(Identifier[name="extra"]) > ObjectLiteralExpression',
       (node) =>
         createObjectLiteralExpression(
           [
@@ -120,7 +120,7 @@ export function generateSentryExpo(tree: Tree, options: SentryGeneratorSchema, p
 
       Sentry.init({
         dsn: Constants.expoConfig?.extra?.sentry?.dsn,
-        environment: Constants.expoConfig?.extra?.env,
+        environment: process.env.EXPO_PUBLIC_APP_ENV,
         debug: false,
         integrations: [navigationIntegration],
         enableNativeFramesTracking: !isRunningInExpoGo(), // Tracks slow and frozen frames in the application


### PR DESCRIPTION
Key changes:
- adjust sentry expo generator and update tests
- correct expo app launch scripts
- update docs to recommend optional local testing with Yalc